### PR TITLE
Fix a `DEFAULT_OWNER` issue of `UniqueId`

### DIFF
--- a/src/main/java/seedu/address/model/id/UniqueId.java
+++ b/src/main/java/seedu/address/model/id/UniqueId.java
@@ -14,16 +14,6 @@ public class UniqueId {
     public static final UniqueId DEFAULT_ID = UniqueId.generateId("00000000-0000-0000-0000-000000000000");
 
     /**
-     * The default owner of {@code UniqueId} that have no owner assigned to it.
-     */
-    private static final HasUniqueId DEFAULT_OWNER = new HasUniqueId() {
-        @Override
-        public UniqueId getId() {
-            return DEFAULT_ID;
-        }
-    };
-
-    /**
      * The owner of the id. It can be a task or a student.
      */
     private HasUniqueId owner;
@@ -36,7 +26,8 @@ public class UniqueId {
     }
 
     private UniqueId(String id) {
-        this.owner = DEFAULT_OWNER;
+        // create a default hasUniqueId for the id's temporary owner.
+        this.owner = () -> UniqueId.generateId(id);
         this.id = UUID.fromString(id);
     }
 

--- a/src/test/java/seedu/address/model/id/UniqueIdTest.java
+++ b/src/test/java/seedu/address/model/id/UniqueIdTest.java
@@ -7,7 +7,6 @@ import static seedu.address.testutil.TypicalObjects.ALICE;
 import static seedu.address.testutil.TypicalTasks.REPORT_1;
 
 import java.util.List;
-import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -41,11 +40,6 @@ public class UniqueIdTest {
 
         assertEquals(task, taskId.getOwner());
         assertEquals(student, studentId.getOwner());
-
-        // test for DEFAULT_OWNER
-        UniqueId noOnwerId1 = UniqueId.generateId(UUID.randomUUID().toString());
-        UniqueId noOnwerId2 = UniqueId.generateId(UUID.randomUUID().toString());
-        assertEquals(noOnwerId1.getOwner(), noOnwerId2.getOwner());
     }
 
     @Test


### PR DESCRIPTION
Currently, all id without an owner will be auto-assigned `DEFAULT_OWNER` as their owner.
However, `DEFAULT_OWNER.getId()` will only return the same id while multiple ids may be assigned to it.

In this PR, `DEFAULT_OWNER` is removed, and instead, each id without an owner assigned to it will be auto-assigned a seperate owner. This may so the issue.