### PR TITLE
Update accurate examples inside Result Display Panel for task commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/tasks/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/AddTaskCommand.java
@@ -17,11 +17,11 @@ public class AddTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "-a";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a task to the address book. "
+    public static final String MESSAGE_USAGE = "task " + COMMAND_WORD + ": Adds a task to the address book. \n"
             + "Parameters: "
             + PREFIX_DESCRIPTION + "NAME "
             + PREFIX_DEADLINE + "DEADLINE\n"
-            + "Example: " + COMMAND_WORD + " "
+            + "Example: " + " task " + COMMAND_WORD + " "
             + PREFIX_DESCRIPTION + "Report 1 "
             + PREFIX_DEADLINE + "2021-01-01";
 

--- a/src/main/java/seedu/address/logic/commands/tasks/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/DeleteTaskCommand.java
@@ -24,10 +24,10 @@ public class DeleteTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "-d";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = "task " + COMMAND_WORD
             + ": Deletes the task identified by the index number used in the displayed task list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + "task " + COMMAND_WORD + " 1";
     public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted Task: %1$s";
 
     private final Index targetIndex;

--- a/src/main/java/seedu/address/logic/commands/tasks/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/tasks/EditTaskCommand.java
@@ -27,13 +27,13 @@ public class EditTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "-e";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the task identified "
+    public static final String MESSAGE_USAGE = "task " + COMMAND_WORD + ": Edits the details of the task identified "
             + "by the index number used in the displayed task list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_DESCRIPTION + "NAME] "
             + "[" + PREFIX_DEADLINE + "DEADLINE]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "Example: " + "task " + COMMAND_WORD + " 1 "
             + PREFIX_DESCRIPTION + "Report 2 "
             + PREFIX_DEADLINE + "2021-01-02";
 

--- a/src/main/java/seedu/address/logic/parser/tasks/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/tasks/EditTaskCommandParser.java
@@ -31,7 +31,7 @@ public class EditTaskCommandParser implements Parser<EditTaskCommand> {
 
         if (argMultimap.getPreamble().isEmpty() || !argMultimap.preambleHasExpectedSegments(1)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditTaskCommand.COMMAND_WORD));
+                    EditTaskCommand.MESSAGE_USAGE));
         }
 
         EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();


### PR DESCRIPTION
Fixes #194 
Previous example displayed if the command is inputted halfway was inaccurate: 
`Example: -a n/CS2100 d/2021-10-10`
Current example displayed will be: 
`Example: task -a n/CS2100 d/2021-10-10`

Update all other task commands with examples written in the Result Display Panel